### PR TITLE
Added REPEAT_ONE as valid Sonos mode in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This component creates a service `sonos_player_modes.set_mode` that lets you cha
 
 ## Service Parameters
 - `entity_id`: entity id of the speaker  (eg. `media_player.bedroom`)
-- `mode`: playback mode. Supported modes: `NORMAL`, `REPEAT_ALL`, `SHUFFLE`, `SHUFFLE_NOREPEAT`
+- `mode`: playback mode. Supported modes: `NORMAL`, `REPEAT_ALL`, `REPEAT_ONE`, `SHUFFLE`, `SHUFFLE_NOREPEAT`

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ This component creates a service `sonos_player_modes.set_mode` that lets you cha
 
 ## Service Parameters
 - `entity_id`: entity id of the speaker  (eg. `media_player.bedroom`)
-- `mode`: playback mode. Supported modes: `NORMAL`, `REPEAT_ALL`, `REPEAT_ONE`, `SHUFFLE`, `SHUFFLE_NOREPEAT`
+- `mode`: playback mode. Supported modes: `NORMAL`, `REPEAT_ALL`, `REPEAT_ONE`, `SHUFFLE`, `SHUFFLE_NOREPEAT`, `SHUFFLE_REPEAT_ONE` 

--- a/custom_components/sonos_player_modes/services.yaml
+++ b/custom_components/sonos_player_modes/services.yaml
@@ -5,5 +5,5 @@ set_mode:
       description: entity_id of the device to set
       example: "media_player.bedroom"
     mode:
-      description: play mode 'NORMAL', 'REPEAT_ALL', 'REPEAT_ONE', 'SHUFFLE', 'SHUFFLE_NOREPEAT'
+      description: play mode 'NORMAL', 'REPEAT_ALL', 'REPEAT_ONE', 'SHUFFLE', 'SHUFFLE_NOREPEAT', 'SHUFFLE_REPEAT_ONE'
       example: "NORMAL"

--- a/custom_components/sonos_player_modes/services.yaml
+++ b/custom_components/sonos_player_modes/services.yaml
@@ -5,5 +5,5 @@ set_mode:
       description: entity_id of the device to set
       example: "media_player.bedroom"
     mode:
-      description: play mode 'NORMAL', 'REPEAT_ALL', 'SHUFFLE', 'SHUFFLE_NOREPEAT'
+      description: play mode 'NORMAL', 'REPEAT_ALL', 'REPEAT_ONE', 'SHUFFLE', 'SHUFFLE_NOREPEAT'
       example: "NORMAL"


### PR DESCRIPTION
Not sure why REPEAT_ONE was left out of original documentation, but I just tested, and it works without issue, so I added it to the list of valid modes.